### PR TITLE
fix: initial position and missing heading, hide vessel if no data about which way to point

### DIFF
--- a/src/components/SVGMarker.tsx
+++ b/src/components/SVGMarker.tsx
@@ -54,12 +54,12 @@ const SVGIcon = (props: SVGIconProps) => (
   <svg width="150px" height="50px" viewBox="-50 -50 325 100">
     <g transform={`rotate(${deg(props.course || 0)})`}>
       <circle r="2" stroke="black" />
-      <polygon
+      {props.course !== undefined && (<polygon
         points="0 -25, 10 15, -10 15"
         fill="none"
         strokeWidth="2"
         stroke="black"
-      />
+      />)}
     </g>
     <g>
       <text x="10" style={{fontSize: 28}}>{props.name ? props.name : ""}</text>

--- a/src/components/VesselDataBundle.ts
+++ b/src/components/VesselDataBundle.ts
@@ -1,5 +1,5 @@
 import { LatLngExpression } from "leaflet"
-import { BehaviorSubject, EMPTY, Observable, Subject } from "rxjs"
+import { BehaviorSubject, EMPTY, Observable, ReplaySubject, Subject } from "rxjs"
 import { map, throttleTime, scan, withLatestFrom, timeoutWith } from "rxjs/operators"
 
 interface LatLngObject {
@@ -18,7 +18,7 @@ export default class VesselDataBundle {
   nameSubject: Subject<string>
 
   constructor() {
-    this.positionSubject = new Subject<LatLngExpression>()
+    this.positionSubject = new ReplaySubject<LatLngExpression>()
     this.positionTimeout = this.positionSubject.pipe(
       timeoutWith(5 * 60 * 1000, EMPTY)
     )
@@ -38,8 +38,8 @@ export default class VesselDataBundle {
         latestPosition,
       ])
     );
-    this.headingSubject = new BehaviorSubject(0)
-    this.speedSubject = new BehaviorSubject(0)
+    this.headingSubject = new ReplaySubject<number>(1)
+    this.speedSubject = new ReplaySubject<number>(1)
     this.nameSubject = new BehaviorSubject('-')
   }
 


### PR DESCRIPTION
Initial position went missing because of not using a ReplaySubject, this PR fixes that. Vessels now render immediately based on the data from cached deltas.

Hide the vessel triangle until we have data about which way to point it. This turns buoys into simple dots to mark the position.