### PR TITLE
fix: chart base layer without charts plugin

### DIFF
--- a/src/components/AppPanel.js
+++ b/src/components/AppPanel.js
@@ -68,7 +68,7 @@ const getInitialViewport = () => {
 
 const fetchCharts = () => fetch('/signalk/v1/api/resources/charts', {
   credentials: 'include'
-}).then(r => r.json())
+}).then(r => r.json()).catch(e => ([]))
 
 
 const AppPanel = (props) => {


### PR DESCRIPTION
Fix defaulting to OpenStreetMap when there is no charts api response.